### PR TITLE
Prepare Hostinger deployment automation

### DIFF
--- a/.cpanel.yml
+++ b/.cpanel.yml
@@ -1,0 +1,8 @@
+---
+deployment:
+  tasks:
+    - export PATH="$HOME/bin:$PATH"
+    - export BACKEND_DEPLOY_PATH="${BACKEND_DEPLOY_PATH:-$HOME/apps/trello-backend}"
+    - export FRONTEND_PUBLIC_PATH="${FRONTEND_PUBLIC_PATH:-$HOME/domains/app.alawalapp.com/public_html}"
+    - export CPANEL_DEPLOY_CONFIG="${CPANEL_DEPLOY_CONFIG:-$HOME/.cpanel/trello-clone.env}"
+    - /bin/bash deployment/cpanel/deploy.sh

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,90 @@
+# Hostinger / cPanel Deployment Guide
+
+This document explains how to publish the Laravel backend and Vite frontend to Hostinger (or any cPanel based) shared hosting with automatic deployments triggered from the `main` branch.
+
+## 1. Prepare the hosting account
+
+1. **Create subdomains**
+   - `api.alawalapp.com` → document root: `/home/<cpanel-user>/apps/trello-backend/public`
+   - `app.alawalapp.com` → document root: `/home/<cpanel-user>/domains/app.alawalapp.com/public_html`
+2. **Install runtimes** (through Hostinger’s cPanel):
+   - PHP 8.2 with the extensions listed in [`backend/DEPLOYMENT.md`](backend/DEPLOYMENT.md).
+   - Composer (`/opt/cpanel/composer/bin/composer`).
+   - Node.js 18 or newer (via Node Version Manager or Hostinger’s NodeJS selector). Note the full path to the `npm` binary, e.g. `/opt/alt/alt-nodejs18/root/usr/bin/npm`.
+3. **Create Git deployment repository** in cPanel → *Git Version Control* → *Create*. Use this GitHub repository URL and keep the clone path (e.g. `/home/<user>/repos/trello-clone`). Set *Automatic Deployment on Commit* to **On**.
+
+## 2. Configure automation variables
+
+`deployment/cpanel/deploy.sh` expects a config file with per-account paths and binary locations. Create the file `~/.cpanel/trello-clone.env` on the server (matching the `CPANEL_DEPLOY_CONFIG` default) with the following contents:
+
+```bash
+# Paths
+BACKEND_DEPLOY_PATH="$HOME/apps/trello-backend"
+FRONTEND_PUBLIC_PATH="$HOME/domains/app.alawalapp.com/public_html"
+
+# Executables (update if Hostinger uses different versions)
+PHP_BIN="/opt/alt/php82/usr/bin/php"
+COMPOSER_BIN="/opt/cpanel/composer/bin/composer"
+NPM_BIN="/opt/alt/alt-nodejs18/root/usr/bin/npm"
+
+# Laravel options
+RUN_MIGRATIONS=true
+RUN_SEEDERS=false
+
+# Frontend build env (optional)
+FRONTEND_ENV_FILE="$HOME/.cpanel/frontend.env"
+```
+
+Create the optional frontend env file so Vite knows where to reach the API:
+
+```bash
+cat > ~/.cpanel/frontend.env <<'ENV'
+VITE_API_URL=https://api.alawalapp.com/api
+ENV
+```
+
+## 3. One-time backend preparation
+
+SSH into the server and run:
+
+```bash
+mkdir -p $HOME/apps/trello-backend
+cd $HOME/apps/trello-backend
+cp $HOME/repos/trello-clone/backend/.env.example .env
+php -r "file_exists('database/database.sqlite') || touch('database/database.sqlite');"
+php artisan key:generate
+# Update .env with production values (APP_URL, database, Redis, mail, Pusher, Sanctum, etc.)
+```
+
+Refer to [`backend/DEPLOYMENT.md`](backend/DEPLOYMENT.md) for full environment variable descriptions, database migration, queue, and websocket configuration.
+
+## 4. One-time frontend preparation
+
+```bash
+mkdir -p $HOME/domains/app.alawalapp.com/public_html
+```
+
+No additional files are needed — the deploy script will publish the Vite `dist/` output to this folder each time.
+
+## 5. Enable automated deployments
+
+With the Git repository already configured in cPanel, every push to `main` will execute `.cpanel.yml`, which calls `deployment/cpanel/deploy.sh` to:
+
+1. Sync the Laravel source into `BACKEND_DEPLOY_PATH` without overwriting `.env` or persistent storage.
+2. Install Composer dependencies and run framework cache optimisations.
+3. Optionally run database migrations and seeders (controlled by `RUN_MIGRATIONS` and `RUN_SEEDERS`).
+4. Build the frontend via `npm ci && npm run build`.
+5. Publish the compiled assets into `FRONTEND_PUBLIC_PATH`.
+
+Check deployment logs in **cPanel → Git Version Control → Manage → History** to confirm successful runs. Errors usually come from missing PHP/Node binaries or incorrect paths in the config file.
+
+## 6. Post-deployment validation checklist
+
+After the first automated deploy:
+
+- Issue a quick request such as `curl -I https://api.alawalapp.com/api/auth/login` to confirm the API responds (a `422 Unprocessable Content` status is expected without credentials).
+- Visit `https://app.alawalapp.com/` to ensure the SPA loads and network calls target the API subdomain defined in `VITE_API_URL`.
+- Review `storage/logs/laravel.log` and the browser console for unexpected errors.
+- Re-run `php artisan queue:work` or `supervisorctl restart` if you manage queue workers outside the deploy script.
+
+Following these steps ensures a repeatable, push-triggered deployment pipeline entirely managed from cPanel.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -45,6 +45,10 @@ PUSHER_PORT=6001
 
 SANCTUM_STATEFUL_DOMAINS=localhost,localhost:3000
 FRONTEND_URL=http://localhost:3000
+# For production SPA deployments uncomment and adjust the following example values:
+# SANCTUM_STATEFUL_DOMAINS=app.example.com
+# FRONTEND_URL=https://app.example.com
+# SESSION_DOMAIN=.example.com
 
 FILESYSTEM_DISK=public
 QUEUE_CONNECTION=database

--- a/backend/DEPLOYMENT.md
+++ b/backend/DEPLOYMENT.md
@@ -1,6 +1,6 @@
 # Deployment Notes (cPanel)
 
-These steps document how to deploy the Laravel backend on a typical cPanel shared hosting environment.
+These steps document how to deploy the Laravel backend on a typical cPanel shared hosting environment. For an end-to-end Hostinger example (including the Vite frontend and automated Git pulls) see the repository-level [`DEPLOYMENT.md`](../DEPLOYMENT.md).
 
 ## Requirements
 

--- a/backend/phpunit.xml
+++ b/backend/phpunit.xml
@@ -24,6 +24,7 @@
         <env name="CACHE_STORE" value="array"/>
         <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
         <!-- <env name="DB_DATABASE" value=":memory:"/> -->
+        <env name="BROADCAST_CONNECTION" value="log"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>

--- a/deployment/cpanel/deploy.sh
+++ b/deployment/cpanel/deploy.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+CONFIG_FILE="${CPANEL_DEPLOY_CONFIG:-$HOME/.cpanel/trello-clone.env}"
+
+if [[ -f "$CONFIG_FILE" ]]; then
+  # shellcheck disable=SC1090
+  source "$CONFIG_FILE"
+fi
+
+: "${BACKEND_DEPLOY_PATH:?Set BACKEND_DEPLOY_PATH in $CONFIG_FILE}"
+: "${FRONTEND_PUBLIC_PATH:?Set FRONTEND_PUBLIC_PATH in $CONFIG_FILE}"
+
+PHP_BIN="${PHP_BIN:-php}"
+COMPOSER_BIN="${COMPOSER_BIN:-composer}"
+NPM_BIN="${NPM_BIN:-npm}"
+
+BACKEND_SOURCE="$ROOT_DIR/backend"
+FRONTEND_SOURCE="$ROOT_DIR/frontend"
+
+log() {
+  printf '\n[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*"
+}
+
+run() {
+  log "Running: $*"
+  "$@"
+}
+
+log "Syncing Laravel backend to $BACKEND_DEPLOY_PATH"
+run mkdir -p "$BACKEND_DEPLOY_PATH"
+run rsync -a --delete \
+  --exclude='.env' \
+  --exclude='node_modules' \
+  --exclude='vendor' \
+  --exclude='storage/app/public' \
+  --exclude='storage/framework/cache/data' \
+  --exclude='storage/framework/sessions' \
+  --exclude='storage/logs' \
+  "$BACKEND_SOURCE"/ "$BACKEND_DEPLOY_PATH"/
+
+pushd "$BACKEND_DEPLOY_PATH" >/dev/null
+  log "Installing Composer dependencies"
+  run "$COMPOSER_BIN" install --no-dev --optimize-autoloader
+
+  log "Running Laravel optimizations"
+  run mkdir -p storage/app/public storage/framework/cache/data storage/framework/sessions storage/logs bootstrap/cache
+  run touch storage/logs/laravel.log
+  run chmod -R ug+rw storage bootstrap/cache
+  run "$PHP_BIN" artisan storage:link || true
+  run "$PHP_BIN" artisan config:cache
+  run "$PHP_BIN" artisan route:cache
+  run "$PHP_BIN" artisan event:cache
+
+  if [[ "${RUN_MIGRATIONS:-true}" == "true" ]]; then
+    log "Running database migrations"
+    run "$PHP_BIN" artisan migrate --force
+  else
+    log "Skipping migrations (RUN_MIGRATIONS=false)"
+  fi
+
+  if [[ "${RUN_SEEDERS:-false}" == "true" ]]; then
+    log "Seeding database"
+    run "$PHP_BIN" artisan db:seed --force
+  fi
+
+  log "Restarting queue workers (if any)"
+  "$PHP_BIN" artisan queue:restart || true
+popd >/dev/null
+
+log "Building frontend"
+pushd "$FRONTEND_SOURCE" >/dev/null
+  CLEAN_FRONTEND_ENV=false
+  if [[ -n "${FRONTEND_ENV_FILE:-}" && -f "$FRONTEND_ENV_FILE" ]]; then
+    log "Copying frontend environment file"
+    cp "$FRONTEND_ENV_FILE" .env.production.local
+    CLEAN_FRONTEND_ENV=true
+  fi
+
+  run "$NPM_BIN" ci
+  run "$NPM_BIN" run build
+
+  if [[ "$CLEAN_FRONTEND_ENV" == true ]]; then
+    rm -f .env.production.local
+  fi
+popd >/dev/null
+
+log "Publishing frontend dist to $FRONTEND_PUBLIC_PATH"
+run mkdir -p "$FRONTEND_PUBLIC_PATH"
+run rsync -a --delete "$FRONTEND_SOURCE/dist"/ "$FRONTEND_PUBLIC_PATH"/
+
+log "Deployment complete"

--- a/frontend/.env.production.example
+++ b/frontend/.env.production.example
@@ -1,0 +1,1 @@
+VITE_API_URL=https://api.example.com/api

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .DS_Store
 .vite
 coverage
+.env.production.local

--- a/frontend/DEPLOYMENT.md
+++ b/frontend/DEPLOYMENT.md
@@ -1,0 +1,19 @@
+# Frontend Deployment Notes
+
+The SPA is built with Vite and expects the backend URL to be provided through the `VITE_API_URL` environment variable. Use `.env.production.local` (ignored by Git) or provide a file referenced by `FRONTEND_ENV_FILE` in `deployment/cpanel/deploy.sh` when building on the server.
+
+Typical production values when the backend lives at `https://api.alawalapp.com`:
+
+```bash
+VITE_API_URL=https://api.alawalapp.com/api
+```
+
+Run the production build locally with:
+
+```bash
+npm ci
+npm run build
+serve -s dist
+```
+
+On cPanel the automatic deployment script handles installing dependencies, running `npm run build`, and publishing the `dist/` folder to the configured document root.

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,6 +1,14 @@
 import axios from 'axios';
 
-const API_BASE_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:8000/api';
+const getDefaultApiUrl = () => {
+  if (window.location.hostname === 'localhost') {
+    return 'http://localhost:8000/api';
+  }
+
+  return `${window.location.origin}/api`;
+};
+
+const API_BASE_URL = import.meta.env.VITE_API_URL ?? getDefaultApiUrl();
 
 export const apiClient = axios.create({
   baseURL: API_BASE_URL,

--- a/frontend/src/components/board/BoardColumn.tsx
+++ b/frontend/src/components/board/BoardColumn.tsx
@@ -1,4 +1,5 @@
-import { useDroppable, SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
+import { useDroppable } from '@dnd-kit/core';
+import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { useMemo } from 'react';
 import type { BoardList } from '../../types';
 import { BoardCard } from './BoardCard';

--- a/frontend/src/providers/EchoProvider.tsx
+++ b/frontend/src/providers/EchoProvider.tsx
@@ -8,8 +8,10 @@ declare global {
   }
 }
 
+type EchoInstance = Echo<any>;
+
 interface EchoContextValue {
-  echo?: Echo;
+  echo?: EchoInstance;
 }
 
 const EchoContext = createContext<EchoContextValue>({});
@@ -19,11 +21,11 @@ interface EchoProviderProps {
 }
 
 export const EchoProvider = ({ children }: EchoProviderProps) => {
-  const [echo, setEcho] = useState<Echo>();
+  const [echo, setEcho] = useState<EchoInstance>();
 
   useEffect(() => {
     window.Pusher = Pusher;
-    const instance = new Echo({
+    const instance: EchoInstance = new Echo({
       broadcaster: 'pusher',
       key: import.meta.env.VITE_PUSHER_KEY ?? 'local',
       wsHost: import.meta.env.VITE_WS_HOST ?? 'localhost',

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,8 +1,9 @@
 {
   "compilerOptions": {
     "composite": true,
+    "target": "ESNext",
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
     "allowSyntheticDefaultImports": true
   },
   "include": ["vite.config.ts"]

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({


### PR DESCRIPTION
## Summary
- add `.cpanel.yml` and a reusable deployment script that installs backend/frontend dependencies, caches Laravel config, runs migrations, and publishes the Vite build for Hostinger
- document the end-to-end Hostinger/cPanel setup plus frontend-specific environment configuration examples
- harden the frontend build (Vite config, tsconfig, Echo typings, API base URL fallback, correct dnd-kit imports) and quiet backend tests by forcing the log broadcaster

## Testing
- `php artisan test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68debdb9e4548325bd11643b6e3e6bb3